### PR TITLE
add precheck of column number, before check column by column

### DIFF
--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -4719,7 +4719,7 @@ locks_ok:
 	use_clustered_index =
 		(index != clust_index && prebuilt->need_to_access_clustered);
 
-	if (use_clustered_index && srv_prefix_index_cluster_optimization) {
+	if (use_clustered_index && srv_prefix_index_cluster_optimization && prebuilt->n_template <= index->n_fields) {
 		/* ...but, perhaps avoid the clustered index lookup if
 		all of the following are true:
 		1) all columns are in the secondary index


### PR DESCRIPTION
Before check column by column, we can check whether the column number required is more than that in the index, if yes, prefix_index_cluster_optimization can not be used for this row.
