### PR TITLE
Fix issue #10 (super read only does not prevent DROP TRIGGER)

### DIFF
--- a/mysql-test/suite/sys_vars/r/super_read_only_basic.result
+++ b/mysql-test/suite/sys_vars/r/super_read_only_basic.result
@@ -213,6 +213,10 @@ connection con1;
 create table t1 (a int);
 insert into t1 values(1);
 create table t2 select * from t1;
+update t1, t2 set t1.a=2, t2.a=2;
+start transaction read write;
+commit;
+create trigger trig before insert on t1 for each row set new.a = new.a;
 connection default;
 #
 # Make sure it blocks SUPER
@@ -221,6 +225,12 @@ set global super_read_only=1;
 create table t3 (a int);
 ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
 drop table t3;
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+update t1, t2 set t1.a=3, t2.a=3;
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+start transaction read write;
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+drop trigger trig;
 ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
 #
 # Make sure it still blocks for non-super
@@ -235,6 +245,12 @@ select @@global.super_read_only;
 create table t3 (a int);
 ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
 insert into t1 values(1);
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+update t1, t2 set t1.a=3, t2.a=3;
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+start transaction read write;
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+drop trigger trig;
 ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
 #
 # Cleanup

--- a/mysql-test/suite/sys_vars/t/super_read_only_basic.test
+++ b/mysql-test/suite/sys_vars/t/super_read_only_basic.test
@@ -159,6 +159,13 @@ insert into t1 values(1);
 
 create table t2 select * from t1;
 
+update t1, t2 set t1.a=2, t2.a=2;
+
+start transaction read write;
+commit;
+
+create trigger trig before insert on t1 for each row set new.a = new.a;
+
 --echo connection default;
 connection default;
 
@@ -175,6 +182,14 @@ create table t3 (a int);
 --error ER_OPTION_PREVENTS_STATEMENT
 drop table t3;
 
+--error ER_OPTION_PREVENTS_STATEMENT
+update t1, t2 set t1.a=3, t2.a=3;
+
+--error ER_OPTION_PREVENTS_STATEMENT
+start transaction read write;
+
+--error ER_OPTION_PREVENTS_STATEMENT
+drop trigger trig;
 
 --echo #
 --echo # Make sure it still blocks for non-super
@@ -192,6 +207,14 @@ create table t3 (a int);
 --error ER_OPTION_PREVENTS_STATEMENT
 insert into t1 values(1);
 
+--error ER_OPTION_PREVENTS_STATEMENT
+update t1, t2 set t1.a=3, t2.a=3;
+
+--error ER_OPTION_PREVENTS_STATEMENT
+start transaction read write;
+
+--error ER_OPTION_PREVENTS_STATEMENT
+drop trigger trig;
 
 --echo #
 --echo # Cleanup

--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -176,7 +176,8 @@ bool trans_begin(THD *thd, uint flags)
       enforce_ro = !(thd->security_ctx->master_access & SUPER_ACL);
     if (opt_readonly && enforce_ro)
     {
-      my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0), "--read-only");
+      my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0),
+               opt_super_readonly ? "--read-only (super)" : "--read-only");
       DBUG_RETURN(true);
     }
     thd->tx_read_only= false;


### PR DESCRIPTION
- add super read only handling to mysql_create_and_drop_trigger;
- tweak error message in trans_begin to note whether regular or super
  read only is effective;
- add MTR tests for the above changes and for multi-table update which
  was implemented but not covered in MTR.

Tested by running super_read_only_basic on a local build. The same patch has undergone Percona Server Jenkins CI testing.
