### PR TITLE
'make' stopped (using FreeBSD)

### DIFF
--- a/sql/net_serv.cc
+++ b/sql/net_serv.cc
@@ -43,6 +43,7 @@
 #include <violite.h>
 #include <signal.h>
 #include <errno.h>
+#include <sys/uio.h>
 #include "probes_mysql.h"
 
 #include <algorithm>


### PR DESCRIPTION
error: 'writev' was not declared in this scope
